### PR TITLE
feat: add product sorted pagination feature

### DIFF
--- a/packages/backend/src/modules/products/products.router.ts
+++ b/packages/backend/src/modules/products/products.router.ts
@@ -4,6 +4,7 @@ import {
   deleteProduct,
   getAllProducts,
   getProduct,
+  paginateProducts,
   restoreProduct,
   updateProduct,
 } from "./products.controller";
@@ -13,9 +14,11 @@ const productsRouter = Router();
 productsRouter
   .get("/products", getAllProducts)
   .post("/products", createProduct)
+  .get("/products/paginate/", paginateProducts)
   .get("/products/:productId", getProduct)
   .put("/products/:productId", updateProduct)
   .delete("/products/:productId", deleteProduct)
-  .put("/products/restore/:productId", restoreProduct);
+  .put("/products/restore/:productId", restoreProduct)
+
 
 export default productsRouter;

--- a/packages/backend/src/utils/productDb.ts
+++ b/packages/backend/src/utils/productDb.ts
@@ -1,7 +1,7 @@
 import { PrismaClient, Product } from "@prisma/client"
 const prisma = new PrismaClient()
 interface structureProduct {
-    id: number | undefined,
+    id: number,
     slug: string,
     name: string,
     description: string,
@@ -65,6 +65,8 @@ export async function queryAllProducts() {
         if (res.length === 0) {
             return { error: 'no hay datos' };
         } else {
+            //para devolver el arreglo ordenado según el id
+            res.sort((a, b) => a.id - b.id);
             return res;
         }
     } catch (error) {
@@ -139,3 +141,23 @@ export async function queryRestore(id: string) {
     }
 }
 
+interface options {
+    column: string;
+    order: 'asc' | 'desc';
+}
+
+export async function queryPaginateAndOrder(currentPage: number, itemsPerPage: number, options: options[]) {
+    const skip = (currentPage - 1) * itemsPerPage;
+    const take = itemsPerPage;
+    const sort = options.map((option) => ({
+        [option.column]: option.order,
+    }));
+
+    const productos = await prisma.product.findMany({
+        skip,
+        take,
+        orderBy: sort,
+    });
+
+    return productos;
+}


### PR DESCRIPTION
Añadido de una ruta de paginación que recibe 3 parámetros por query : current : number , items : number , options : [] ó un [{column: "name-column", order: "asc o desc"}]  dependiendo si tiene opciones para el ordenamiento, de no tener se espera que sea un array vacío.